### PR TITLE
Fix crash with long autocomments

### DIFF
--- a/xAnalyzer/xanalyzer.cpp
+++ b/xAnalyzer/xanalyzer.cpp
@@ -80,7 +80,7 @@ void GenAPIInfo()
 	char szAPIComment[MAX_COMMENT_SIZE] = "";
 	char szMainModule[MAX_MODULE_SIZE] = "";
 	char szDisasmText[GUI_MAX_DISASSEMBLY_SIZE] = "";
-	char szAPIDefinition[MAX_PATH] = "";
+	char szAPIDefinition[MAX_COMMENT_SIZE] = "";
 
 	ZeroMemory(&bii, sizeof(BASIC_INSTRUCTION_INFO));
 	ZeroMemory(&cbii, sizeof(BASIC_INSTRUCTION_INFO));


### PR DESCRIPTION
Thanks for making this plugin, it's very good!

This PR fixes a crash I got because szAPIDefinition sometimes can't fit the complete autocomment. This gives the useless message 'stack corruption occurred around szAPIDefinition' in Visual Studio. It only seems to happen rarely, I actually came across this while investigating another crash (but that one looks like an x64dbg bug).