### PR TITLE
Arguments passed using mov instruction (mov* [ebp*], ... or mov* [esp…

### DIFF
--- a/xAnalyzer/plugin.cpp
+++ b/xAnalyzer/plugin.cpp
@@ -119,7 +119,7 @@ PLUG_EXPORT void CBMENUENTRY(CBTYPE cbType, PLUG_CB_MENUENTRY* info)
  			mbp.cbSize = sizeof(MSGBOXPARAMS);
  			mbp.hInstance = pluginHInstance;
  			mbp.lpszCaption = "About...";
- 			mbp.lpszText = "["PLUGIN_NAME " " PLUGIN_VERSION_STR"]\n"
+ 			mbp.lpszText = "[" PLUGIN_NAME " " PLUGIN_VERSION_STR"]\n"
  							"Extended analysis for static code \n\n"
  							"http://github.com/ThunderCls/xAnalyzer\n"
  							"Coded By : ThunderCls - 2016\n"

--- a/xAnalyzer/pluginmain.cpp
+++ b/xAnalyzer/pluginmain.cpp
@@ -2,7 +2,7 @@
 #include "plugin.h"
 
 // Variables
-const char *szprojectnameInfo = "\n"PLUGIN_NAME " " PLUGIN_VERSION_STR" Plugin by ThunderCls 2017\n"
+const char *szprojectnameInfo = "\n" PLUGIN_NAME " " PLUGIN_VERSION_STR" Plugin by ThunderCls 2017\n"
 								"Extended analysis for static code\n"
 								"-> For latest release, issues, etc....\n"
 								"-> For help type command \"xanal help\"\n"

--- a/xAnalyzer/xAnalyzer.vcxproj
+++ b/xAnalyzer/xAnalyzer.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -27,28 +27,28 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
…*], ...) are recognized, Functions ending with Stub are also recognized, small bugfix with string concatenation

Also upgraded project to VS2015, i don't have VS2013 not sure if that's an issue